### PR TITLE
refactor: 의존성 주입 패턴으로 NetworkMonitor 적용 및 FlightsService Firebase 초기화 수정

### DIFF
--- a/app/core/network_monitor.py
+++ b/app/core/network_monitor.py
@@ -190,6 +190,3 @@ class NetworkMonitor:
                     self._status = NetworkStatus.OFFLINE
                     self._notify_listeners(NetworkStatus.OFFLINE)
 
-
-# Exports만 유지
-__all__ = ["NetworkMonitor", "NetworkStatus"]

--- a/app/feature/flights/flights_service.py
+++ b/app/feature/flights/flights_service.py
@@ -28,6 +28,7 @@ class FlightsService:
             firebase_service: Firebase 서비스 인스턴스
         """
         self.amadeus_client = amadeus_client
+        self.firebase_service = firebase_service
         self.db = firebase_service.db
         self.airports_collection = self.db.collection("airports")
 
@@ -95,7 +96,7 @@ class FlightsService:
             # 지연 임포트로 순환 참조 방지
             from app.feature.airlines.airline_service import AirlineService
             
-            airline_service = AirlineService(firebase_service=FirebaseService())
+            airline_service = AirlineService(firebase_service=self.firebase_service)
             airline_stats_map = {}
             for code in airline_codes:
                 # 병렬 처리하면 좋겠지만, 일단 순차 처리 (캐싱 고려 가능)

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.feature.wellness import wellness_router
 from app.feature.notifications import notification_router
 from app.feature.offline import offline_router
 from app.feature.flights import flights_router
+from app.feature.airlines import airline_router
 
 # 2. Firebase 초기화 실행
 from app.core import firebase
@@ -125,3 +126,4 @@ app.include_router(wellness_router.router)
 app.include_router(notification_router.router)
 app.include_router(offline_router.router)
 app.include_router(flights_router.router)
+app.include_router(airline_router.router)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 
 # 1. 기능별 라우터 import
-from app.feature.LLM import llm_router
+from app.feature.llm import llm_router
 from app.feature.auth import auth_router
 from app.feature.reviews import reviews_router
 from app.feature.wellness import wellness_router
@@ -69,13 +69,11 @@ async def lifespan(app: FastAPI):
     # LocalDatabase
     local_db = LocalDatabase()
     
-    # SyncQueue (DI 적용)
-    sync_queue = SyncQueue()
-    # TODO: 나중에 SyncQueue도 의존성 주입 패턴 적용 시 network_monitor 주입
+    # SyncQueue (의존성 주입 적용)
+    sync_queue = SyncQueue(network_monitor=network_monitor)
     
-    # CacheService
-    cache_service = CacheService()
-    # TODO: 나중에 CacheService도 의존성 주입 패턴 적용 시 수정
+    # CacheService (의존성 주입 적용)
+    cache_service = CacheService(network_monitor=network_monitor)
     
     # OfflineService (의존성 주입)
     offline_service = OfflineService(


### PR DESCRIPTION
# refactor: 의존성 주입 패턴으로 NetworkMonitor 적용

## 변경 사항

- SyncQueue와 CacheService에 NetworkMonitor 의존성 주입 적용
- main.py의 lifespan에서 NetworkMonitor를 생성하여 주입
- 싱글톤 패턴 대신 명시적 의존성 주입으로 변경하여 테스트 용이성 향상
- get_network_monitor() 함수는 하위 호환성을 위해 유지

## 변경 이유

기존에는 `SyncQueue`와 `CacheService`가 내부에서 `get_network_monitor()`를 호출하여 싱글톤 인스턴스를 가져왔습니다. 이를 의존성 주입 패턴으로 변경하여:

1. **명시적 의존성**: 생성자에서 필요한 의존성을 명확히 확인 가능
2. **테스트 용이성**: Mock 객체 주입이 쉬워짐
3. **제어 역전**: 객체 생성과 의존성 관리가 중앙화됨 (main.py의 lifespan에서)
4. **단일 책임**: 각 클래스가 자신의 책임에만 집중

## 수정된 파일

- `app/core/network_monitor.py`: 싱글톤 함수 추가 (하위 호환성)
- `app/feature/offline/cache_service.py`: NetworkMonitor를 생성자 매개변수로 받도록 변경
- `app/feature/offline/sync_queue.py`: NetworkMonitor를 생성자 매개변수로 받도록 변경
- `app/main.py`: lifespan에서 NetworkMonitor를 생성하여 주입

## 테스트

- [x] 서버 정상 시작 확인
- [x] API 엔드포인트 정상 동작 확인
- [x] 모듈 import 성공 확인

---

# fix: FlightsService에서 초기화된 FirebaseService 인스턴스 사용

## 변경 사항

- AirlineService 생성 시 새로운 FirebaseService() 인스턴스를 생성하던 문제 수정
- 의존성 주입으로 전달된 초기화된 firebase_service 인스턴스 사용하도록 변경
- Firebase 초기화 오류 해결

## 변경 이유

`FlightsService`의 `search_flights` 메서드에서 `AirlineService`를 생성할 때, 새로운 `FirebaseService()` 인스턴스를 생성하여 사용하고 있었습니다. 이 인스턴스는 초기화되지 않은 상태였기 때문에 "Firebase가 초기화되지 않았습니다" 오류가 발생했습니다.

의존성 주입으로 전달된 이미 초기화된 `firebase_service` 인스턴스를 사용하도록 변경하여 문제를 해결했습니다.

## 수정된 파일

- `app/feature/flights/flights_service.py`
  - `__init__`에서 `firebase_service`를 인스턴스 변수로 저장
  - `AirlineService` 생성 시 `self.firebase_service` 사용

## 테스트

- [x] Swagger에서 `/flights/search` API 정상 동작 확인
- [x] Firebase 초기화 오류 해결 확인
