### PR TITLE
Feature/flight search sorting

### DIFF
--- a/app/core/clients/amadeus.py
+++ b/app/core/clients/amadeus.py
@@ -100,8 +100,7 @@ class AmadeusClient:
                             departureDate=departure_date,
                             returnDate=return_date,
                             adults=adults,
-                            max=100,  # 최대 100개 결과 반환
-                            sort="-price",  # 가격 높은순 정렬
+                            max=75,  # 최대 75개 결과 반환
                         )
                     else:
                         # 편도 항공편 검색
@@ -110,8 +109,7 @@ class AmadeusClient:
                             destinationLocationCode=destination.upper(),
                             departureDate=departure_date,
                             adults=adults,
-                            max=100,  # 최대 100개 결과 반환
-                            sort="-price",  # 가격 높은순 정렬
+                            max=75,  # 최대 75개 결과 반환
                         )
 
                     # 응답 데이터 반환

--- a/app/core/clients/amadeus.py
+++ b/app/core/clients/amadeus.py
@@ -100,7 +100,8 @@ class AmadeusClient:
                             departureDate=departure_date,
                             returnDate=return_date,
                             adults=adults,
-                            max=50,  # 최대 50개 결과 반환
+                            max=100,  # 최대 100개 결과 반환
+                            sort="-price",  # 가격 높은순 정렬
                         )
                     else:
                         # 편도 항공편 검색
@@ -109,7 +110,8 @@ class AmadeusClient:
                             destinationLocationCode=destination.upper(),
                             departureDate=departure_date,
                             adults=adults,
-                            max=50,  # 최대 50개 결과 반환
+                            max=100,  # 최대 100개 결과 반환
+                            sort="-price",  # 가격 높은순 정렬
                         )
 
                     # 응답 데이터 반환

--- a/app/core/network_monitor.py
+++ b/app/core/network_monitor.py
@@ -190,6 +190,3 @@ class NetworkMonitor:
                     self._status = NetworkStatus.OFFLINE
                     self._notify_listeners(NetworkStatus.OFFLINE)
 
-
-# Exports만 유지
-__all__ = ["NetworkMonitor", "NetworkStatus"]

--- a/app/feature/airlines/airline_service.py
+++ b/app/feature/airlines/airline_service.py
@@ -326,14 +326,20 @@ class AirlineService:
             
             data = doc.to_dict()
             
-            # 전체 평균 평점 계산
-            avg_ratings = data.get("averageRatings", {})
-            if avg_ratings:
-                overall_rating = round(sum(avg_ratings.values()) / len(avg_ratings), 2)
+            # Firestore에 저장된 overallRating이 있으면 우선 사용, 없으면 계산
+            if "overallRating" in data and data["overallRating"] is not None:
+                overall_rating = data["overallRating"]
             else:
-                overall_rating = 0.0
+                # 전체 평균 평점 계산 (overallRating이 없는 경우에만)
+                avg_ratings = data.get("averageRatings", {})
+                if avg_ratings:
+                    overall_rating = round(sum(avg_ratings.values()) / len(avg_ratings), 2)
+                else:
+                    overall_rating = 0.0
+                # 계산한 값을 data에 저장
+                data["overallRating"] = overall_rating
             
-            # overallRating 필드 추가
+            # overallRating 필드가 data에 확실히 포함되도록 보장
             data["overallRating"] = overall_rating
             
             return AirlineSchema(**data)

--- a/app/feature/flights/flights_schemas.py
+++ b/app/feature/flights/flights_schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, ConfigDict
-from typing import Dict, Literal, Optional, List
+from typing import Dict, Literal, Optional, List, Any
 from datetime import datetime, timezone
 
 class MyFlightSchema(BaseModel):
@@ -100,8 +100,8 @@ class FlightSearchRequest(BaseModel):
         json_schema_extra={
             "example": {
                 "origin": "ICN",
-                "destination": "JFK",
-                "departure_date": "2025-06-15",
+                "destination": "LHR",
+                "departure_date": "2025-12-30",
                 "adults": 1
             }
         }
@@ -124,8 +124,8 @@ class SegmentSchema(BaseModel):
     departure: Dict = Field(..., description="출발 정보 (공항 코드, 시간 등)")
     arrival: Dict = Field(..., description="도착 정보 (공항 코드, 시간 등)")
     carrier_code: str = Field(..., alias="carrierCode", description="항공사 코드")
-    number: str = Field(..., description="항공편 번호")
-    aircraft: Optional[Dict] = Field(None, description="항공기 정보")
+    number: str = Field(..., description="항공편 번호(KE901)")
+    aircraft: Optional[Dict] = Field(None, description="항공기 정보(Boeing 737-800)")
     duration: Optional[str] = Field(None, description="비행 시간")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -206,14 +206,16 @@ class FlightSearchResponse(BaseModel):
     """
     항공편 검색 응답 스키마
     """
-    flight_offers: List[FlightOfferSchema] = Field(..., description="검색된 항공편 제안 리스트")
     count: int = Field(..., description="검색된 항공편 개수")
-
+    flight_offers: List[Dict] = Field(..., description="검색된 항공편 제안 리스트")
+    airlines: List[AirlineSchema] = Field(default_factory=list, description="검색 결과에 포함된 항공사 정보 목록 (overallRating 내림차순 정렬)")
+    
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "flight_offers": [],
-                "count": 0
+                "count": 0,
+                "airlines": []
             }
         }
     )

--- a/app/feature/flights/flights_service.py
+++ b/app/feature/flights/flights_service.py
@@ -28,6 +28,7 @@ class FlightsService:
             firebase_service: Firebase 서비스 인스턴스
         """
         self.amadeus_client = amadeus_client
+        self.firebase_service = firebase_service
         self.db = firebase_service.db
         self.airports_collection = self.db.collection("airports")
 
@@ -95,7 +96,7 @@ class FlightsService:
             # 지연 임포트로 순환 참조 방지
             from app.feature.airlines.airline_service import AirlineService
             
-            airline_service = AirlineService(firebase_service=FirebaseService())
+            airline_service = AirlineService(firebase_service=self.firebase_service)
             airline_stats_map = {}
             for code in airline_codes:
                 # 병렬 처리하면 좋겠지만, 일단 순차 처리 (캐싱 고려 가능)

--- a/app/feature/flights/flights_service.py
+++ b/app/feature/flights/flights_service.py
@@ -115,7 +115,7 @@ class FlightsService:
                     if code in airline_stats_map:
                         offer.airline_info = airline_stats_map[code]
             
-            # 5. 정렬 (요청된 경우)
+            # 5. 정렬 (기본값: overallRating 내림차순, 요청된 경우 해당 정렬 적용)
             if request.sort_by:
                 if request.sort_by == "rating_desc":
                     flight_offers.sort(
@@ -132,6 +132,12 @@ class FlightsService:
                     flight_offers.sort(
                         key=lambda x: float(x.price.total) if x.price.total else float('inf')
                     )
+            else:
+                # 기본 정렬: overallRating 내림차순
+                flight_offers.sort(
+                    key=lambda x: x.airline_info.overallRating if x.airline_info else 0.0, 
+                    reverse=True
+                )
 
             return FlightSearchResponse(
                 flight_offers=flight_offers,

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.feature.wellness import wellness_router
 from app.feature.notifications import notification_router
 from app.feature.offline import offline_router
 from app.feature.flights import flights_router
+from app.feature.airlines import airline_router
 
 # 2. Firebase 초기화 실행
 from app.core import firebase
@@ -125,3 +126,4 @@ app.include_router(wellness_router.router)
 app.include_router(notification_router.router)
 app.include_router(offline_router.router)
 app.include_router(flights_router.router)
+app.include_router(airline_router.router)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 
 # 1. 기능별 라우터 import
-from app.feature.LLM import llm_router
+from app.feature.llm import llm_router
 from app.feature.auth import auth_router
 from app.feature.reviews import reviews_router
 from app.feature.wellness import wellness_router
@@ -69,13 +69,11 @@ async def lifespan(app: FastAPI):
     # LocalDatabase
     local_db = LocalDatabase()
     
-    # SyncQueue (DI 적용)
-    sync_queue = SyncQueue()
-    # TODO: 나중에 SyncQueue도 의존성 주입 패턴 적용 시 network_monitor 주입
+    # SyncQueue (의존성 주입 적용)
+    sync_queue = SyncQueue(network_monitor=network_monitor)
     
-    # CacheService
-    cache_service = CacheService()
-    # TODO: 나중에 CacheService도 의존성 주입 패턴 적용 시 수정
+    # CacheService (의존성 주입 적용)
+    cache_service = CacheService(network_monitor=network_monitor)
     
     # OfflineService (의존성 주입)
     offline_service = OfflineService(


### PR DESCRIPTION
# 항공편 검색 결과 정렬 기능 개선

## 개요
항공편 검색 API(`/flights/search`)에서 Amadeus API 검색 결과를 Firestore의 airlines collection에 저장된 `overallRating` 기준으로 정렬하여 반환하도록 개선했습니다.

## 변경 사항

### 1. Amadeus API 최대 검색 결과 수를 75개로 증가
- Amadeus API 호출 시 `max` 파라미터를 50에서 75로 증가
- 더 많은 항공편 옵션을 제공하여 사용자 선택의 폭 확대
- (참고: Amadeus API의 `sort` 파라미터는 `flight_offers_search` 엔드포인트에서 지원되지 않아 제거됨)

### 2. 항공사 코드 수집 로직 개선
- `validating_airline_codes`가 없는 경우 segments의 `carrierCode`를 사용하여 항공사 코드 수집
- 모든 항공편의 항공사 정보를 정확하게 수집하여 Firestore 조회 성공률 향상

### 3. Firestore의 overallRating 우선 사용
- `get_airline_statistics` 메서드에서 Firestore에 저장된 `overallRating` 필드를 우선 사용
- Firestore에 `overallRating`이 없을 경우에만 `averageRatings`로부터 계산
- 실시간 업데이트된 평점이 즉시 반영되도록 개선

### 4. 항공편 검색 결과를 Firestore airlines collection의 overallRating 기준 내림차순으로 정렬
- Amadeus API에서 받아온 항공편 검색 결과에 대해
- 각 항공편의 항공사 코드를 추출하여 Firestore의 `airlines/{airlineCode}` 문서에서 `overallRating` 조회
- 조회한 `overallRating` 값을 기준으로 내림차순 정렬하여 클라이언트에 반환

### 5. 기본 정렬을 overallRating 내림차순으로 설정
- `sort_by` 파라미터가 제공되지 않은 경우 기본적으로 `overallRating` 내림차순으로 정렬
- 사용자가 다른 정렬 옵션(`rating_desc`, `review_count_desc`, `price_asc`)을 요청한 경우 해당 정렬 적용

### 6. 각 항공편 결과에 overallRating 필드 추가
- 각 항공편 검색 결과에 `overallRating` 필드를 직접 포함
- 클라이언트에서 각 항공편의 평점을 바로 확인 가능

### 7. 검색 결과에 포함된 항공사 목록(airlines) 추가
- 검색 결과에 포함된 항공사들의 정보를 별도 목록으로 제공
- 항공사 목록은 `overallRating` 기준 내림차순으로 정렬
- 클라이언트에서 항공사별 필터링 및 정렬에 활용 가능

### 8. duration 필드 포맷팅
- ISO 8601 duration 형식(`PT35H14M`)을 간단한 형식(`35H14M`)으로 변환
- `itinerary.duration`과 `segment.duration` 모두 적용

### 9. 클라이언트 응답에서 불필요한 필드 제외
- 내부적으로만 사용되는 필드들을 응답에서 제외
- 제외된 필드: `id`, `source`, `instant_ticketing_required`, `non_homogeneous`, `last_ticketing_date`, `validating_airline_codes`, `traveler_pricings`, `airline_info`
- 클라이언트 응답이 더 간결하고 명확해짐

## 수정된 파일
- `app/core/clients/amadeus.py`
  - `max` 파라미터를 75로 변경

- `app/feature/airlines/airline_service.py`
  - `get_airline_statistics` 메서드에서 Firestore의 `overallRating` 필드를 우선 사용하도록 수정
  - Firestore에 `overallRating`이 없을 경우에만 `averageRatings`로부터 계산

- `app/feature/flights/flights_schemas.py`
  - `FlightOfferSchema`에 `airline_info` 필드 추가 (내부 로직용)
  - `FlightSearchResponse`에 `airlines` 필드 추가 (항공사 목록)

- `app/feature/flights/flights_service.py`
  - segments의 `carrierCode`를 사용하여 항공사 코드 수집 로직 개선
  - `search_flights` 메서드에 기본 정렬 로직 추가
  - `overallRating` 기준 내림차순 정렬을 기본값으로 설정
  - 각 항공편 결과에 `overallRating` 필드 추가
  - 검색 결과에 포함된 항공사 목록 생성 및 정렬
  - duration 필드 포맷팅 로직 추가
  - 클라이언트 응답에서 불필요한 필드 제외

## 동작 흐름
1. 클라이언트가 `/flights/search` API 호출
2. Amadeus API에서 항공편 검색 (최대 75개)
3. 검색 결과에서 각 항공편의 항공사 코드 수집
   - `validating_airline_codes`에서 추출 시도
   - 없으면 segments의 `carrierCode`에서 추출
4. Firestore `airlines` collection에서 각 항공사의 `overallRating` 조회
   - Firestore에 저장된 `overallRating` 필드를 우선 사용
5. 각 항공편에 항공사 정보(`airline_info`) 주입
6. 검색 결과에 포함된 항공사 목록 생성 및 `overallRating` 기준 정렬
7. 항공편들을 `overallRating` 기준 내림차순 정렬 (기본값)
8. 각 항공편에 `overallRating` 필드 추가 및 duration 포맷팅
9. 불필요한 필드 제외 후 정렬된 결과를 클라이언트에 반환

## 테스트
- [ ] Amadeus API에서 최대 75개의 검색 결과가 반환되는지 확인
- [ ] segments의 `carrierCode`를 사용하여 항공사 코드가 올바르게 수집되는지 확인
- [ ] Firestore에서 항공사 정보가 올바르게 조회되는지 확인
- [ ] Firestore의 `overallRating` 필드가 우선 사용되는지 확인
- [ ] `overallRating` 기준 내림차순 정렬이 올바르게 동작하는지 확인
- [ ] 각 항공편 결과에 `overallRating` 필드가 포함되는지 확인
- [ ] 검색 결과에 `airlines` 목록이 포함되고 정렬되는지 확인
- [ ] duration 필드가 올바르게 포맷팅되는지 확인 (PT35H14M -> 35H14M)
- [ ] 불필요한 필드가 응답에서 제외되는지 확인
- [ ] `sort_by` 파라미터가 제공된 경우 해당 정렬이 적용되는지 확인

