### PR TITLE
feat: myFlights 데이터를 활용한 시차적응 계획 생성 기능 추가

### DIFF
--- a/app/feature/flights/__init__.py
+++ b/app/feature/flights/__init__.py
@@ -1,4 +1,5 @@
 from app.feature.flights import flights_router
+from app.feature.flights import my_flights_router
 
-__all__ = ["flights_router"]
+__all__ = ["flights_router", "my_flights_router"]
 

--- a/app/feature/flights/flights_schemas.py
+++ b/app/feature/flights/flights_schemas.py
@@ -13,6 +13,8 @@ class MyFlightSchema(BaseModel):
     arrivalTime: datetime
     status: Literal["scheduled", "completed"]
     reviewId: Optional[str] = None
+    departureAirport: Optional[str] = Field(None, description="출발 공항 코드 (예: ICN)")
+    arrivalAirport: Optional[str] = Field(None, description="도착 공항 코드 (예: JFK)")
 
     model_config = ConfigDict(
         from_attributes=True,
@@ -23,6 +25,8 @@ class MyFlightSchema(BaseModel):
                 "departureTime": "2025-12-25T13:45:00Z",
                 "arrivalTime": "2025-12-25T18:20:00Z",
                 "status": "scheduled",
+                "departureAirport": "ICN",
+                "arrivalAirport": "JFK",
             }
         }
     )

--- a/app/feature/wellness/wellness_router.py
+++ b/app/feature/wellness/wellness_router.py
@@ -2,15 +2,29 @@
 시차적응 및 피로도 관리 API 라우터
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from app.feature.wellness import wellness_schemas, wellness_service
+from app.feature.flights.my_flights_service import MyFlightsService
+from app.core.deps import get_firebase_service
+from app.core.firebase import FirebaseService
+from app.core.security import verify_firebase_token
 
 router = APIRouter(
     prefix="/wellness",
     tags=["Wellness"],
     responses={404: {"description": "Not found"}},
 )
+
+security = HTTPBearer()
+
+
+def get_my_flights_service(
+    firebase_service: FirebaseService = Depends(get_firebase_service)
+) -> MyFlightsService:
+    """MyFlightsService 의존성 주입"""
+    return MyFlightsService(firebase_service=firebase_service)
 
 
 @router.post("/jetlag-plan", response_model=wellness_schemas.JetLagPlanResponse)
@@ -39,6 +53,82 @@ async def generate_jetlag_plan(request: wellness_schemas.JetLagPlanRequest):
         - **post_arrival_tips**: 도착 후 팁
         - **algorithm_explanation**: LLM이 생성한 알고리즘 설명
     """
+    return await wellness_service.generate_jetlag_plan(request)
+
+
+@router.post("/users/{user_id}/my-flights/{flight_id}/jetlag-plan", response_model=wellness_schemas.JetLagPlanResponse)
+async def generate_jetlag_plan_from_my_flight(
+    user_id: str,
+    flight_id: str,
+    destination_timezone: str,
+    origin_timezone: str = None,
+    user_sleep_pattern_start: str = None,
+    user_sleep_pattern_end: str = None,
+    trip_duration_days: int = None,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    my_flights_service: MyFlightsService = Depends(get_my_flights_service)
+):
+    """
+    myFlights에 저장된 비행 정보를 기반으로 시차적응 계획을 생성합니다.
+    
+    - **user_id**: 사용자 ID
+    - **flight_id**: myFlights에 저장된 비행 기록 ID
+    - **destination_timezone**: 도착지 시간대 (예: "America/New_York")
+    - **origin_timezone**: 출발지 시간대 (선택사항, 예: "Asia/Seoul")
+    - **user_sleep_pattern_start**: 사용자 평소 수면 시작 시간 (선택사항, HH:MM 형식)
+    - **user_sleep_pattern_end**: 사용자 평소 수면 종료 시간 (선택사항, HH:MM 형식)
+    - **trip_duration_days**: 여행 기간 (선택사항, 기본값: 7일)
+    
+    Returns:
+        - **origin_timezone**: 출발지 시간대
+        - **destination_timezone**: 도착지 시간대
+        - **time_difference_hours**: 시차 (시간 단위)
+        - **total_flight_duration_hours**: 총 비행 시간
+        - **daily_schedules**: 일별 일정 (수면 시간, 식사 시간, 활동 등)
+        - **general_recommendations**: 일반적인 권장사항
+        - **pre_flight_tips**: 출발 전 팁
+        - **post_arrival_tips**: 도착 후 팁
+        - **algorithm_explanation**: LLM이 생성한 알고리즘 설명
+    """
+    # 인증 확인
+    token = credentials.credentials
+    decoded_token = verify_firebase_token(token)
+    token_user_id = decoded_token.get("uid")
+    
+    if token_user_id != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="You don't have permission to access this resource"
+        )
+    
+    # myFlights에서 비행 정보 조회
+    my_flight = await my_flights_service.get_flight_by_id(user_id, flight_id)
+    if not my_flight:
+        raise HTTPException(
+            status_code=404,
+            detail="비행 기록을 찾을 수 없습니다."
+        )
+    
+    # MyFlightSchema를 FlightSegment로 변환
+    try:
+        flight_segment = wellness_service.convert_my_flight_to_segment(my_flight)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=str(e)
+        )
+    
+    # JetLagPlanRequest 생성
+    request = wellness_schemas.JetLagPlanRequest(
+        flight_segments=[flight_segment],
+        destination_timezone=destination_timezone,
+        origin_timezone=origin_timezone,
+        user_sleep_pattern_start=user_sleep_pattern_start,
+        user_sleep_pattern_end=user_sleep_pattern_end,
+        trip_duration_days=trip_duration_days
+    )
+    
+    # 시차적응 계획 생성
     return await wellness_service.generate_jetlag_plan(request)
 
 

--- a/app/feature/wellness/wellness_service.py
+++ b/app/feature/wellness/wellness_service.py
@@ -15,6 +15,7 @@ from app.feature.wellness.wellness_schemas import (
 )
 from app.feature.llm import llm_service
 from app.feature.llm.llm_schemas import LLMChatRequest
+from app.feature.flights.flights_schemas import MyFlightSchema
 
 
 def calculate_time_difference(origin_tz: str, dest_tz: str) -> int:
@@ -269,4 +270,32 @@ def _extract_recommendations(llm_response: str, section_name: str) -> List[str]:
         return items if items else []
     
     return []
+
+
+def convert_my_flight_to_segment(my_flight: MyFlightSchema) -> FlightSegment:
+    """
+    MyFlightSchema를 FlightSegment로 변환합니다.
+    
+    Args:
+        my_flight: 사용자의 비행 기록
+        
+    Returns:
+        FlightSegment 객체
+        
+    Raises:
+        ValueError: 공항 정보가 없는 경우
+    """
+    if not my_flight.departureAirport or not my_flight.arrivalAirport:
+        raise ValueError("출발지 또는 도착지 공항 정보가 필요합니다.")
+    
+    # 비행 시간 계산
+    duration = (my_flight.arrivalTime - my_flight.departureTime).total_seconds() / 3600
+    
+    return FlightSegment(
+        departure_airport=my_flight.departureAirport,
+        arrival_airport=my_flight.arrivalAirport,
+        departure_time=my_flight.departureTime,
+        arrival_time=my_flight.arrivalTime,
+        flight_duration_hours=duration
+    )
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from app.feature.reviews import reviews_router
 from app.feature.wellness import wellness_router
 from app.feature.notifications import notification_router
 from app.feature.offline import offline_router
-from app.feature.flights import flights_router
+from app.feature.flights import flights_router, my_flights_router
 from app.feature.airlines import airline_router
 
 # 2. Firebase 초기화 실행
@@ -126,4 +126,5 @@ app.include_router(wellness_router.router)
 app.include_router(notification_router.router)
 app.include_router(offline_router.router)
 app.include_router(flights_router.router)
+app.include_router(my_flights_router.router)
 app.include_router(airline_router.router)


### PR DESCRIPTION
# 🚀 myFlights 데이터를 활용한 시차적응 계획 생성 기능

## 📋 개요

Firestore에 저장된 사용자의 비행 기록(`myFlights`)을 활용하여 시차적응 계획을 자동으로 생성하는 기능을 추가했습니다. 기존에는 클라이언트에서 직접 비행 정보를 입력해야 했지만, 이제는 저장된 비행 기록을 기반으로 시차적응 계획을 생성할 수 있습니다.

## ✨ 주요 변경사항

### 1. MyFlightSchema 확장

- `departureAirport`, `arrivalAirport` 필드를 optional로 추가
- 기존 데이터와의 호환성 유지 (기존 데이터는 그대로 동작)

```python
class MyFlightSchema(BaseModel):
    # ... 기존 필드들 ...
    departureAirport: Optional[str] = Field(None, description="출발 공항 코드 (예: ICN)")
    arrivalAirport: Optional[str] = Field(None, description="도착 공항 코드 (예: JFK)")
```

### 2. 데이터 변환 함수 추가

- `wellness_service.convert_my_flight_to_segment()` 함수 추가
- `MyFlightSchema`를 `FlightSegment`로 변환
- 공항 정보가 없을 경우 `ValueError` 발생

```python
def convert_my_flight_to_segment(my_flight: MyFlightSchema) -> FlightSegment:
    """
    MyFlightSchema를 FlightSegment로 변환합니다.
    """
    if not my_flight.departureAirport or not my_flight.arrivalAirport:
        raise ValueError("출발지 또는 도착지 공항 정보가 필요합니다.")

    duration = (my_flight.arrivalTime - my_flight.departureTime).total_seconds() / 3600

    return FlightSegment(
        departure_airport=my_flight.departureAirport,
        arrival_airport=my_flight.arrivalAirport,
        departure_time=my_flight.departureTime,
        arrival_time=my_flight.arrivalTime,
        flight_duration_hours=duration
    )
```

### 3. 새로운 API 엔드포인트 추가

- `POST /wellness/users/{user_id}/my-flights/{flight_id}/jetlag-plan`
- Firebase 인증을 통한 사용자 권한 확인
- myFlights 데이터를 자동으로 조회하여 시차적응 계획 생성

```python
@router.post("/users/{user_id}/my-flights/{flight_id}/jetlag-plan",
             response_model=wellness_schemas.JetLagPlanResponse)
async def generate_jetlag_plan_from_my_flight(
    user_id: str,
    flight_id: str,
    destination_timezone: str,
    origin_timezone: str = None,
    user_sleep_pattern_start: str = None,
    user_sleep_pattern_end: str = None,
    trip_duration_days: int = None,
    credentials: HTTPAuthorizationCredentials = Depends(security),
    my_flights_service: MyFlightsService = Depends(get_my_flights_service)
):
    # 인증 확인
    # myFlights 데이터 조회
    # FlightSegment로 변환
    # 시차적응 계획 생성
```

### 4. 의존성 주입 설정

- `MyFlightsService` 의존성 주입 함수 추가
- `FirebaseService`를 통한 Firestore 접근

## 📝 API 사용 예시

### 요청

```bash
POST /wellness/users/{user_id}/my-flights/{flight_id}/jetlag-plan
Authorization: Bearer {firebase_token}

Query Parameters:
- destination_timezone: "America/New_York" (필수)
- origin_timezone: "Asia/Seoul" (선택)
- user_sleep_pattern_start: "23:00" (선택)
- user_sleep_pattern_end: "07:00" (선택)
- trip_duration_days: 7 (선택, 기본값: 7)
```

### 응답

기존 `/wellness/jetlag-plan` 엔드포인트와 동일한 응답 형식:

```json
{
  "origin_timezone": "Asia/Seoul",
  "destination_timezone": "America/New_York",
  "time_difference_hours": -13,
  "total_flight_duration_hours": 14.5,
  "daily_schedules": [...],
  "general_recommendations": [...],
  "pre_flight_tips": [...],
  "post_arrival_tips": [...],
  "algorithm_explanation": "..."
}
```

## 🔒 보안

- Firebase 인증 토큰 검증
- 사용자 ID 일치 확인 (403 에러 반환)
- 비행 기록이 존재하지 않을 경우 404 에러 반환
- 공항 정보가 없을 경우 400 에러 반환

## ⚠️ 주의사항

1. **공항 정보 필수**: myFlights에 `departureAirport`, `arrivalAirport` 정보가 있어야 합니다.
2. **기존 데이터**: 기존에 저장된 비행 기록에는 공항 정보가 없을 수 있으므로, 비행 기록 생성/수정 시 공항 정보를 함께 저장해야 합니다.
3. **하위 호환성**: 기존 엔드포인트(`POST /wellness/jetlag-plan`)는 그대로 유지되며 계속 사용 가능합니다.

## 📁 변경된 파일

- `app/feature/flights/flights_schemas.py`: MyFlightSchema 확장
- `app/feature/wellness/wellness_service.py`: 변환 함수 추가
- `app/feature/wellness/wellness_router.py`: 새로운 엔드포인트 추가

## 🧪 테스트

- [ ] 새로운 엔드포인트 동작 확인
- [ ] 인증 및 권한 검증 테스트
- [ ] 공항 정보 없을 경우 에러 처리 테스트
- [ ] 기존 엔드포인트와의 호환성 확인

## 🔗 관련 이슈

- 사용자가 저장한 비행 기록을 활용한 시차적응 계획 자동 생성 요구사항
