### PR TITLE
feat: /search/airlines API에 항공사 평점 정보 추가 및 정렬 기능 구현

### DIFF
--- a/app/feature/airlines/airline_router.py
+++ b/app/feature/airlines/airline_router.py
@@ -70,7 +70,7 @@ async def get_airline_detail(
     
     - **airline_code**: 항공사 코드 (예: KE, AF, SQ)
     """
-    airline = await service.get_airline_with_bimo(airline_code)
+    airline = await service.get_airline_statistics(airline_code)
     if not airline:
         raise HTTPException(status_code=404, detail="항공사를 찾을 수 없습니다.")
     return airline

--- a/app/feature/flights/flights_schemas.py
+++ b/app/feature/flights/flights_schemas.py
@@ -481,6 +481,8 @@ class AirlineSearchResponseItem(BaseModel):
     flight_number: str = Field(..., description="항공편명 (첫 번째 구간의 항공편명, 예: KE123)")
     total_duration: str = Field(..., description="총 비행 시간 (예: 14H30M)")
     segments: List[SegmentDetailSchema] = Field(..., description="각 구간별 비행 시간 및 정보 (경유일 경우 여러 개)")
+    overall_rating: Optional[float] = Field(None, description="항공사 전체 평점 (Firestore에서 조회, 없으면 null)")
+    total_reviews: Optional[int] = Field(None, description="총 리뷰 수 (Firestore에서 조회, 없으면 null)")
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -490,6 +492,8 @@ class AirlineSearchResponseItem(BaseModel):
                 "has_stopover": False,
                 "flight_number": "KE123",
                 "total_duration": "14H30M",
+                "overall_rating": 4.2,
+                "total_reviews": 1250,
                 "segments": [
                     {
                         "operating_carrier": "KE",

--- a/app/feature/flights/flights_service.py
+++ b/app/feature/flights/flights_service.py
@@ -43,6 +43,7 @@ class FlightsService:
         if firebase_service:
             self.db = firebase_service.db
             self.airports_collection = self.db.collection("airports")
+            self.airlines_collection = self.db.collection("airlines")
     
     @staticmethod
     def _format_duration(duration: str) -> str:
@@ -307,6 +308,57 @@ class FlightsService:
         # 3. 둘 다 없으면 0M 반환
         return "0M"
 
+    async def _fetch_airlines_batch(self, airline_codes: List[str]) -> Dict[str, Dict[str, float | int]]:
+        """
+        여러 항공사 코드로 Firestore에서 배치 조회
+        
+        Args:
+            airline_codes: 항공사 코드 리스트 (예: ["KE", "OZ", "SQ"])
+            
+        Returns:
+            {airline_code: {"overallRating": float, "totalReviews": int}} 딕셔너리
+            존재하지 않는 항공사는 딕셔너리에 포함하지 않음
+        """
+        if not airline_codes or not self.firebase_service:
+            return {}
+        
+        result = {}
+        
+        def _fetch():
+            """동기 함수로 Firestore 문서들을 조회"""
+            docs = {}
+            for code in airline_codes:
+                doc_ref = self.airlines_collection.document(code)
+                doc = doc_ref.get()
+                if doc.exists:
+                    docs[code] = doc
+            return docs
+        
+        docs = await run_in_threadpool(_fetch)
+        
+        for code, doc in docs.items():
+            data = doc.to_dict()
+            if data:
+                # overallRating 계산 (get_airline_statistics와 동일한 로직)
+                if "overallRating" in data and data["overallRating"] is not None:
+                    overall_rating = data["overallRating"]
+                else:
+                    # 전체 평균 평점 계산 (overallRating이 없는 경우에만)
+                    avg_ratings = data.get("averageRatings", {})
+                    if avg_ratings:
+                        overall_rating = round(sum(avg_ratings.values()) / len(avg_ratings), 2)
+                    else:
+                        overall_rating = 0.0
+                
+                total_reviews = data.get("totalReviews", 0)
+                
+                result[code] = {
+                    "overallRating": overall_rating,
+                    "totalReviews": total_reviews
+                }
+        
+        return result
+
     async def search_airlines(self, request: AirlineSearchRequest) -> AirlineSearchResponse:
         """
         Duffel API를 사용하여 항공편을 검색하고, 동일한 operating carrier만 필터링하여 반환합니다.
@@ -337,8 +389,9 @@ class FlightsService:
             if not offers:
                 return AirlineSearchResponse(count=0, results=[])
             
-            # 3. 동일한 operating carrier만 필터링
-            filtered_results = []
+            # 3. 동일한 operating carrier만 필터링 및 항공사 코드 수집
+            filtered_offers = []
+            airline_codes_set = set()
             
             for offer in offers:
                 try:
@@ -418,20 +471,52 @@ class FlightsService:
                             )
                         )
                     
-                    filtered_results.append(
-                        AirlineSearchResponseItem(
-                            operating_carrier=operating_carrier,
-                            logo_symbol_url=logo_symbol_url,
-                            has_stopover=has_stopover,
-                            flight_number=first_flight_number,
-                            total_duration=total_duration,
-                            segments=segment_details,
-                        )
-                    )
+                    # 필터링된 offer 정보 저장
+                    filtered_offers.append({
+                        "operating_carrier": operating_carrier,
+                        "logo_symbol_url": logo_symbol_url,
+                        "has_stopover": has_stopover,
+                        "flight_number": first_flight_number,
+                        "total_duration": total_duration,
+                        "segments": segment_details,
+                    })
+                    
+                    # 항공사 코드 수집
+                    airline_codes_set.add(operating_carrier)
                     
                 except Exception as e:
                     logger.warning(f"Offer 파싱 실패: {str(e)}")
                     continue
+            
+            # 4. 항공사 정보 배치 조회
+            airline_info_map = {}
+            if airline_codes_set:
+                airline_info_map = await self._fetch_airlines_batch(list(airline_codes_set))
+            
+            # 5. 결과 생성 시 항공사 정보 병합
+            filtered_results = []
+            for offer_data in filtered_offers:
+                operating_carrier = offer_data["operating_carrier"]
+                airline_info = airline_info_map.get(operating_carrier, {})
+                
+                filtered_results.append(
+                    AirlineSearchResponseItem(
+                        operating_carrier=operating_carrier,
+                        logo_symbol_url=offer_data["logo_symbol_url"],
+                        has_stopover=offer_data["has_stopover"],
+                        flight_number=offer_data["flight_number"],
+                        total_duration=offer_data["total_duration"],
+                        segments=offer_data["segments"],
+                        overall_rating=airline_info.get("overallRating"),
+                        total_reviews=airline_info.get("totalReviews"),
+                    )
+                )
+            
+            # 6. overallRating 기준 내림차순 정렬 (None 값은 맨 뒤로)
+            filtered_results.sort(
+                key=lambda x: (x.overall_rating is None, -(x.overall_rating or 0)),
+                reverse=False
+            )
             
             return AirlineSearchResponse(
                 count=len(filtered_results),


### PR DESCRIPTION
# feat: /search/airlines API에 항공사 평점 정보 추가 및 정렬 기능 구현

## 변경 사항

- AirlineSearchResponseItem에 overall_rating, total_reviews 필드 추가
- FlightsService에 _fetch_airlines_batch 메서드 추가 (배치 조회)
- search_airlines 메서드에서 Firestore에서 항공사 정보 조회 및 병합
- overallRating 기준 내림차순 정렬 기능 추가

## 주요 기능

- /search/airlines API 응답에 각 항공편의 operating_carrier에 해당하는 overallRating과 totalReviews 추가
- Firestore에서 배치 조회로 성능 최적화
- 항공사 정보가 없는 경우 null 반환

## 상세 설명

### 1. 스키마 변경 (`flights_schemas.py`)
- `AirlineSearchResponseItem` 모델에 다음 필드 추가:
  - `overall_rating: Optional[float]` - 항공사 전체 평점
  - `total_reviews: Optional[int]` - 총 리뷰 수

### 2. 배치 조회 메서드 추가 (`flights_service.py`)
- `_fetch_airlines_batch` 메서드 구현
  - 여러 항공사 코드를 한 번에 Firestore에서 조회
  - `{airline_code: {"overallRating": float, "totalReviews": int}}` 형식으로 반환
  - 존재하지 않는 항공사는 딕셔너리에 포함하지 않음

### 3. 검색 로직 개선 (`flights_service.py`)
- `search_airlines` 메서드 수정:
  1. 필터링된 항공편의 `operating_carrier` 코드 수집
  2. 수집된 항공사 코드로 배치 조회 수행
  3. 각 결과 항목에 항공사 정보 병합
  4. `overallRating` 기준 내림차순 정렬 (None 값은 맨 뒤로)

## 성능 최적화

- 배치 조회를 사용하여 Firestore 읽기 횟수 최소화
- 중복 항공사 코드 제거로 불필요한 조회 방지

## 응답 예시

```json
{
  "count": 2,
  "results": [
    {
      "operating_carrier": "KE",
      "logo_symbol_url": "https://...",
      "has_stopover": false,
      "flight_number": "KE123",
      "total_duration": "14H30M",
      "overall_rating": 3.56,
      "total_reviews": 30,
      "segments": [...]
    },
    {
      "operating_carrier": "OZ",
      "logo_symbol_url": "https://...",
      "has_stopover": true,
      "flight_number": "OZ501",
      "total_duration": "16H20M",
      "overall_rating": null,
      "total_reviews": null,
      "segments": [...]
    }
  ]
}
```

## 관련 이슈

- `/airlines/sorting` API의 결과값과 동일한 데이터 소스 사용
- Duffel API 호출 결과의 `operating_carrier`와 Firestore의 항공사 데이터 매칭

