### PR TITLE
Firestore read optimization

### DIFF
--- a/app/feature/airlines/airline_router.py
+++ b/app/feature/airlines/airline_router.py
@@ -46,9 +46,9 @@ async def get_airlines_sorted_by_rating(
     service = Depends(get_airline_service)
 ):
     """
-    모든 항공사를 overallRating 순으로 정렬하여 조회합니다.
+    overallRating 상위 10개 항공사를 조회합니다.
     
-    Firestore airlines collection에 저장된 항공사들을 overallRating 내림차순으로 정렬하여 반환합니다.
+    Firestore airlines collection에서 overallRating 내림차순 정렬 + limit(10)으로 조회하여 반환합니다.
     """
     return await service.get_airlines_sorted_by_rating()
 

--- a/app/feature/airlines/airline_service.py
+++ b/app/feature/airlines/airline_service.py
@@ -40,9 +40,37 @@ class _AsyncTTLCache:
             self._value = value
             self._expires_at = time.time() + self._ttl_seconds
 
+    async def get_or_set(self, loader):
+        """캐시가 비었거나 만료되었으면 loader로 채운 뒤 반환합니다.
+
+        loader: async callable (no-arg) -> value
+        """
+        cached = await self.get()
+        if cached is not None:
+            return cached
+
+        async with self._lock:
+            # lock 획득 후 다시 확인 (single-flight)
+            cached = await self.get()
+            if cached is not None:
+                return cached
+            value = await loader()
+            self._value = value
+            self._expires_at = time.time() + self._ttl_seconds
+            return value
+
+    def clear(self):
+        """테스트/운영 중 수동 무효화를 위한 캐시 초기화."""
+        self._value = None
+        self._expires_at = 0.0
+
 
 # /airlines/sorting 결과(상위 10개)를 짧게 캐싱해서 트래픽이 있을 때 Firestore read를 크게 줄입니다.
 _AIRLINES_SORTED_TOP10_CACHE = _AsyncTTLCache(ttl_seconds=60)
+
+# /airlines/search에서 전체 airlines를 매 요청마다 읽지 않도록, 전체 목록을 짧게 캐싱합니다.
+# (Firestore는 기본적으로 substring(contains) 검색이 어려워, 동작을 유지하려면 메모리 필터링이 필요)
+_AIRLINES_ALL_CACHE = _AsyncTTLCache(ttl_seconds=300)
 
 
 class AirlineService:
@@ -83,6 +111,33 @@ class AirlineService:
         if v == 0:
             return 0
         return (v / (v + m)) * R + (m / (v + m)) * C
+
+    @staticmethod
+    def _extract_overall_rating(data: dict) -> float:
+        """airlines 문서에서 overallRating을 최대한 일관되게 추출합니다.
+
+        우선순위:
+        1) overallRating (집계 필드)
+        2) averageRatings['overall'] (문서 스키마에 따라 존재 가능)
+        3) averageRatings 평균(값이 숫자라는 가정)
+        """
+        if "overallRating" in data and data["overallRating"] is not None:
+            return float(data["overallRating"])
+
+        avg_ratings = data.get("averageRatings", {})
+        if isinstance(avg_ratings, dict) and avg_ratings:
+            if "overall" in avg_ratings and avg_ratings["overall"] is not None:
+                try:
+                    return float(avg_ratings["overall"])
+                except Exception:
+                    return 0.0
+            try:
+                values = [float(v) for v in avg_ratings.values() if v is not None]
+                return round(sum(values) / len(values), 2) if values else 0.0
+            except Exception:
+                return 0.0
+
+        return 0.0
     
     async def search_airlines(self, query: str) -> List[Airline]:
         """
@@ -98,31 +153,33 @@ class AirlineService:
             return []
             
         try:
-            # 데모 로직: 전체 다 가져와서 필터링 (데이터가 적다는 가정)
-            # 프로덕션에서는 Algolia 등 전문 검색 엔진 사용 권장
-            docs = await run_in_threadpool(lambda: list(self.airlines_collection.stream()))
-            results = []
-            query_lower = query.lower()
-            
-            for doc in docs:
-                data = doc.to_dict()
-                airline_name = data.get("airlineName", "")
-                
-                if query_lower in airline_name.lower():
-                    airline = Airline(
-                        id=doc.id,
-                        name=airline_name,
-                        code=doc.id,
-                        country=data.get("country", ""),
-                        alliance=data.get("alliance"),
-                        type=data.get("type", "FSC"),
-                        rating=data.get("overallRating", 0.0),
-                        review_count=data.get("totalReviews", 0),
-                        logo_url=data.get("logoUrl"),
+            # substring(contains) 검색을 유지하기 위해 서버에서 필터링이 필요합니다.
+            # 다만 매 요청마다 Firestore 전체 read를 피하기 위해 전체 목록을 TTL 캐싱합니다.
+            async def _load_all_airlines() -> List[Airline]:
+                docs = await run_in_threadpool(lambda: list(self.airlines_collection.stream()))
+                all_airlines: List[Airline] = []
+                for doc in docs:
+                    data = doc.to_dict()
+                    airline_name = data.get("airlineName", "")
+                    all_airlines.append(
+                        Airline(
+                            id=doc.id,
+                            name=airline_name,
+                            code=doc.id,
+                            country=data.get("country", ""),
+                            alliance=data.get("alliance"),
+                            type=data.get("type", "FSC"),
+                            rating=self._extract_overall_rating(data),
+                            review_count=data.get("totalReviews", 0),
+                            logo_url=data.get("logoUrl"),
+                        )
                     )
-                    results.append(airline)
-            
-            return results
+                return all_airlines
+
+            all_airlines = await _AIRLINES_ALL_CACHE.get_or_set(_load_all_airlines)
+
+            query_lower = query.lower()
+            return [a for a in all_airlines if query_lower in (a.name or "").lower()]
         except Exception as e:
             if isinstance(e, CustomException):
                 raise e
@@ -279,6 +336,9 @@ class AirlineService:
             return result
 
         except Exception as e:
+            # 입력값 검증 오류는 그대로 올려서 FastAPI/상위 레이어에서 4xx로 처리할 수 있게 합니다.
+            if isinstance(e, ValueError):
+                raise
             if isinstance(e, CustomException):
                 raise e
             raise DatabaseError(message=f"주차별 인기 항공사 조회 중 오류 발생: {e}")
@@ -401,16 +461,7 @@ class AirlineService:
             for doc in docs:
                 data = doc.to_dict()
                 
-                # overallRating 계산 (get_airline_statistics와 동일한 로직)
-                if "overallRating" in data and data["overallRating"] is not None:
-                    overall_rating = data["overallRating"]
-                else:
-                    # 전체 평균 평점 계산 (overallRating이 없는 경우에만)
-                    avg_ratings = data.get("averageRatings", {})
-                    if avg_ratings:
-                        overall_rating = round(sum(avg_ratings.values()) / len(avg_ratings), 2)
-                    else:
-                        overall_rating = 0.0
+                overall_rating = self._extract_overall_rating(data)
                 
                 airline = Airline(
                     id=doc.id,

--- a/app/feature/airlines/airline_service.py
+++ b/app/feature/airlines/airline_service.py
@@ -3,6 +3,8 @@
 경로: airlines/{airlineCode}
 """
 
+import asyncio
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
@@ -12,6 +14,35 @@ from app.core.firebase import FirebaseService
 from app.feature.airlines.models import Airline, AirlineDetail
 from app.feature.flights.flights_schemas import AirlineSchema
 from app.core.exceptions.exceptions import DatabaseError, CustomException
+
+
+class _AsyncTTLCache:
+    """간단한 프로세스(인스턴스) 메모리 TTL 캐시.
+
+    - 여러 FastAPI worker/인스턴스 환경에서는 각 프로세스마다 따로 캐시됩니다.
+    - Firestore read를 줄이기 위한 'best effort' 캐시입니다.
+    """
+
+    def __init__(self, ttl_seconds: int):
+        self._ttl_seconds = ttl_seconds
+        self._expires_at: float = 0.0
+        self._value = None
+        self._lock = asyncio.Lock()
+
+    async def get(self):
+        now = time.time()
+        if self._value is not None and now < self._expires_at:
+            return self._value
+        return None
+
+    async def set(self, value):
+        async with self._lock:
+            self._value = value
+            self._expires_at = time.time() + self._ttl_seconds
+
+
+# /airlines/sorting 결과(상위 10개)를 짧게 캐싱해서 트래픽이 있을 때 Firestore read를 크게 줄입니다.
+_AIRLINES_SORTED_TOP10_CACHE = _AsyncTTLCache(ttl_seconds=60)
 
 
 class AirlineService:
@@ -350,14 +381,20 @@ class AirlineService:
     
     async def get_airlines_sorted_by_rating(self) -> List[Airline]:
         """
-        모든 항공사를 overallRating 순으로 정렬하여 반환합니다.
+        overallRating 상위 항공사(기본 10개)를 반환합니다.
         
         Returns:
-            overallRating 내림차순으로 정렬된 항공사 목록
+            overallRating 내림차순으로 정렬된 항공사 목록 (상위 10개)
         """
         try:
-            # 모든 항공사 조회
-            docs = await run_in_threadpool(lambda: list(self.airlines_collection.stream()))
+            # 트래픽이 많을 때 Firestore read를 줄이기 위해 top10 결과를 짧게 캐싱
+            cached = await _AIRLINES_SORTED_TOP10_CACHE.get()
+            if cached is not None:
+                return cached
+
+            # Firestore에서 정렬 + limit으로 필요한 문서만 조회 (요청당 read를 10으로 고정)
+            query = self.airlines_collection.order_by("overallRating", direction="DESCENDING").limit(10)
+            docs = await run_in_threadpool(lambda: list(query.stream()))
             
             all_airlines = []
             
@@ -388,13 +425,10 @@ class AirlineService:
                 )
                 all_airlines.append(airline)
             
-            # overallRating 내림차순 정렬
-            sorted_airlines = sorted(
-                all_airlines,
-                key=lambda x: x.rating,
-                reverse=True
-            )
-            
+            # 이미 Firestore에서 정렬되어 오지만, 안전하게 한 번 더 정렬 (fallback 계산 케이스 대응)
+            sorted_airlines = sorted(all_airlines, key=lambda x: x.rating, reverse=True)
+
+            await _AIRLINES_SORTED_TOP10_CACHE.set(sorted_airlines)
             return sorted_airlines
                 
         except Exception as e:

--- a/app/feature/reviews/reviews_router.py
+++ b/app/feature/reviews/reviews_router.py
@@ -10,7 +10,7 @@ from typing import Optional, Annotated
 from app.core.deps import get_firebase_service, get_gemini_client
 from app.core.firebase import FirebaseService
 from app.core.security import decode_access_token
-from app.core.exceptions.exceptions import InvalidTokenError
+from app.core.exceptions.exceptions import InvalidTokenError, CustomException
 from app.feature.llm.gemini_client import GeminiClient
 from app.feature.reviews.reviews_service import ReviewsService
 from app.feature.reviews import reviews_schemas
@@ -113,8 +113,15 @@ async def get_detailed_reviews(
             limit=limit,
             offset=offset
         )
+    except HTTPException:
+        # FastAPI 표준 예외는 그대로 전달
+        raise
+    except CustomException:
+        # CustomException(DatabaseError 등)은 app-level handler에서 표준 포맷으로 처리되도록 그대로 올립니다.
+        raise
     except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        # 그 외 알 수 없는 예외는 500으로 노출
+        raise HTTPException(status_code=500, detail=f"서버 오류가 발생했습니다: {str(e)}")
 
 
 @router.post("", response_model=reviews_schemas.ReviewSchema, status_code=201)

--- a/app/feature/reviews/reviews_service.py
+++ b/app/feature/reviews/reviews_service.py
@@ -619,7 +619,7 @@ class ReviewsService:
             # 사진 리뷰 수집
             photo_urls = []
             for review in filtered_response.reviews:
-                if review.imageUrl:
+                if hasattr(review, 'imageUrl') and review.imageUrl:
                     photo_urls.append(review.imageUrl)
             
             return DetailedReviewsResponse(

--- a/tests/unit/test_airlines.py
+++ b/tests/unit/test_airlines.py
@@ -21,6 +21,10 @@ def mock_firebase_service():
 @pytest.fixture
 def airline_service(mock_firebase_service):
     """AirlineService 인스턴스 생성"""
+    # 전역 TTL 캐시가 테스트 간에 영향을 주지 않도록 초기화
+    import app.feature.airlines.airline_service as airline_service_module
+    airline_service_module._AIRLINES_SORTED_TOP10_CACHE.clear()
+    airline_service_module._AIRLINES_ALL_CACHE.clear()
     return AirlineService(firebase_service=mock_firebase_service)
 
 


### PR DESCRIPTION
## PR 제목
Firestore read 최적화 및 /reviews/detailed 404 에러 수정

## 배경
### Firestore read 최적화
- `/airlines/sorting`: 전체 문서를 매 요청마다 읽은 뒤 서버에서 정렬 → Firestore read 과도 발생
- `/airlines/search`: 전체 문서를 매 요청마다 읽어서 필터링 → Firestore read 과도 발생

### /reviews/detailed 404 에러
- 모든 예외를 404로 변환하는 로직으로 인해 실제 에러 원인 파악 불가
- `imageUrl` 접근 시 속성 체크 없이 접근 → 예외 발생

## 변경사항
### 1. /airlines/sorting read 최적화
  - Firestore 쿼리로 `order_by("overallRating", DESC) + limit(10)` 적용
  - 기존 전체 `stream()` + 서버 정렬 로직 제거
  - **60초 TTL 메모리 캐시 추가**(프로세스/인스턴스 단위)
    - 동일 프로세스에서 반복 호출 시 Firestore 접근 없이 응답
  - 라우터 설명을 "상위 10개 조회"로 명확화

### 2. /airlines/search read 최적화
  - **5분 TTL 메모리 캐시 추가**
    - 전체 항공사 목록을 캐싱 후 메모리에서 substring 필터링
    - 기존: 요청마다 전체 문서 read → 변경: 5분에 1번만 read
  - `_extract_overall_rating()` 헬퍼 메서드 추가
    - `overallRating` 또는 `averageRatings`에서 평점 일관되게 추출
  - 테스트 안정화: 전역 캐시 clear 추가

### 3. /reviews/detailed/{airline_code} 404 에러 수정
  - **`CustomException` import 추가** (`reviews_router.py`)
    - 기존: 모든 예외를 404로 변환 → 디버깅 불가
    - 변경: CustomException은 app-level handler로 전달, 나머지는 500
  - **안전한 속성 접근** (`reviews_service.py`)
    - `imageUrl` 접근 시 `hasattr` 체크 추가
    - 사진 리뷰 수집 중 예외 발생해도 계속 진행
  - 예외 처리 순서 개선: HTTPException → CustomException → Exception

## 구현 상세
### 수정 파일
1. **`app/feature/airlines/airline_service.py`**
   - `get_airlines_sorted_by_rating()`: `order_by + limit(10)` 사용
   - `search_airlines()`: 전체 항공사 목록 5분 TTL 캐시
   - `_AsyncTTLCache` 클래스 추가 (TTL 기반 메모리 캐시)
   - `_extract_overall_rating()` 헬퍼 메서드 추가

2. **`app/feature/airlines/airline_router.py`**
   - `/airlines/sorting` 엔드포인트 docstring 수정

3. **`app/feature/reviews/reviews_router.py`**
   - `CustomException` import 추가
   - `get_detailed_reviews()` 예외 처리 개선

4. **`app/feature/reviews/reviews_service.py`**
   - `get_detailed_reviews_page()`: 안전한 `imageUrl` 접근

5. **`tests/unit/test_airlines.py`**
   - 전역 캐시 clear 추가 (테스트 격리)

## 기대 효과
### Firestore read 감소
- **`/airlines/sorting`**
  - 기존: (항공사 문서 수) 만큼 매 요청 read 발생
  - 변경: **최대 10 reads/요청**
  - 캐시 히트 시: **0 reads/요청**(동일 프로세스 기준)

- **`/airlines/search`**
  - 기존: (항공사 문서 수) 만큼 매 요청 read 발생
  - 변경: **5분에 1번만 전체 read**
  - 캐시 히트 시: **0 reads/요청**(동일 프로세스 기준)

### 안정성 개선
- **`/reviews/detailed/{airline_code}`**
  - 404 에러 해결 → 200 OK 정상 응답
  - 예외 발생 시 정확한 상태코드/메시지 반환 (디버깅 용이)

## 주의/제약
- **메모리 캐시는 프로세스(인스턴스)별**이라, 서버가 여러 인스턴스로 오토스케일되는 환경에서는 캐시 효과가 분산됩니다.
  - 더 강한 절감이 필요하면 Redis 같은 **공유 캐시** 또는 **사전집계(top10 문서 1개) 방식** 권장
- Firestore `order_by("overallRating")`는 프로젝트 설정에 따라 **인덱스 생성이 필요**할 수 있습니다.
- 일부 문서에 `overallRating`이 없을 경우 fallback 계산을 유지했지만, 정렬 기준 필드는 `overallRating`이므로 데이터 적재 시 해당 필드를 채워두는 것이 가장 안정적입니다.

## 테스트
- **로컬 코드 정적 확인(린트)**: 이상 없음
- **단위 테스트**: `tests/unit/test_airlines.py` 전체 통과 (11개)
- **기능 테스트 (실제 요청)**
  - `/airlines/sorting` → 200 OK (상위 10개 반환)
  - `/airlines/search?query=대한` → 200 OK (캐시 적용)
  - `/reviews/detailed/KE?sort=latest&limit=100&offset=0` → 200 OK (404 해결)

## 후속 작업(선택)
- **검색 성능 추가 개선**
  - `/airlines/search`: prefix 검색용 정규화 필드 + range query 도입
  - 또는 Algolia 등 전문 검색 엔진 도입 검토
- **공유 캐시 도입 (Redis)**
  - 현재 메모리 캐시는 프로세스별 → 여러 인스턴스 환경에서 효과 분산
  - Redis로 전환 시 모든 인스턴스가 캐시 공유 → read 절감 효과 극대화

