### PR TITLE
fix: hasReview 업데이트 로직 개선 및 수동 동기화 API 추가

### DIFF
--- a/app/feature/flights/flights_schemas.py
+++ b/app/feature/flights/flights_schemas.py
@@ -451,6 +451,15 @@ class SegmentHasReviewStatusSchema(BaseModel):
     hasReview: bool = Field(False, description="해당 segment에 대한 리뷰 작성 여부")
 
 
+class UpdateReviewStatusRequest(BaseModel):
+    """
+    myFlights의 특정 segment에 대한 리뷰 상태 업데이트 요청
+    """
+    airlineCode: str = Field(..., description="항공사 코드 (예: KE)")
+    flightNumber: str = Field(..., description="항공편 번호 (예: KE0037, 0037, 37 등)")
+    hasReview: bool = Field(..., description="리뷰 작성 여부 (true/false)")
+
+
 class MyFlightSegmentsHasReviewItemSchema(BaseModel):
     """
     myFlights 문서(1개)에 대한 segment별 hasReview 결과

--- a/app/feature/flights/my_flights_router.py
+++ b/app/feature/flights/my_flights_router.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Body
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from app.feature.flights.flights_schemas import MyFlightSchema, MyFlightsSegmentsHasReviewResponse
+from app.feature.flights.flights_schemas import MyFlightSchema, MyFlightsSegmentsHasReviewResponse, UpdateReviewStatusRequest
 from app.feature.flights.my_flights_service import MyFlightsService
 from app.core.security import decode_access_token
 from app.core.deps import get_firebase_service
@@ -130,6 +130,34 @@ async def get_my_flights_segments_has_review(
     - 응답에는 `myFlights` 문서 ID가 포함됩니다.
     """
     return await service.get_segments_has_review(user_id=user_id, status=status, limit=limit)
+
+
+@router.put("/segments/review-status", response_model=dict)
+async def update_segment_review_status_api(
+    user_id: str,
+    request: UpdateReviewStatusRequest,
+    current_user_id: str = Depends(get_current_user_id),
+    service: MyFlightsService = Depends(get_my_flights_service)
+):
+    """
+    특정 항공편 segment의 hasReview 상태를 명시적으로 업데이트합니다.
+    Firestore에 저장된 포맷(snake_case, 0-padded 숫자 등)에 상관없이 매칭되도록 처리합니다.
+    
+    - **airlineCode**: 항공사 코드 (예: "KE")
+    - **flightNumber**: 편명 (예: "37", "0037", "KE0037" 모두 가능)
+    - **hasReview**: true(작성됨) 또는 false(삭제됨/미작성)
+    """
+    success = await service.update_segment_review_status(
+        user_id=user_id,
+        airline_code=request.airlineCode,
+        flight_number=request.flightNumber,
+        has_review=request.hasReview
+    )
+    
+    return {
+        "success": success,
+        "message": "리뷰 상태가 업데이트되었습니다." if success else "업데이트 실패"
+    }
 
 
 @router.get("/{flight_id}", response_model=MyFlightSchema)

--- a/app/feature/flights/my_flights_service.py
+++ b/app/feature/flights/my_flights_service.py
@@ -232,7 +232,7 @@ class MyFlightsService:
         Args:
             user_id: 사용자 ID
             airline_code: 항공사 코드 (예: "KE")
-            flight_number: 항공편 번호 (예: "KE901", 선택사항)
+            flight_number: 항공편 번호 (예: "KE901", "0037", "37" 등)
             has_review: 리뷰 작성 여부 (True: 리뷰 작성됨, False: 리뷰 없음)
             
         Returns:
@@ -249,8 +249,14 @@ class MyFlightsService:
             
             # 매칭되는 segment 찾기 및 업데이트
             updated_count = 0
-            airline_code_upper = airline_code.upper()
-            flight_number_upper = flight_number.upper()
+            airline_code_upper = airline_code.upper().strip()
+            
+            # 입력된 편명에서 숫자만 추출 (예: "KE37" -> "37", "0037" -> "37")
+            target_flight_num_str = "".join(filter(str.isdigit, flight_number))
+            if target_flight_num_str:
+                target_flight_num = int(target_flight_num_str)
+            else:
+                target_flight_num = -1  # 숫자가 없는 경우
             
             for doc in docs:
                 flight_data = doc.to_dict()
@@ -259,30 +265,63 @@ class MyFlightsService:
                 # segments 배열에서 매칭되는 segment 찾기
                 updated = False
                 for i, segment in enumerate(segments):
-                    segment_carrier = segment.get("operating_carrier", "").upper()
-                    segment_flight = segment.get("flight_number", "").upper()
+                    # 1. 항공사 코드 확인 (snake_case 우선, camelCase 대비)
+                    seg_carrier = (
+                        segment.get("operating_carrier") or 
+                        segment.get("operatingCarrier") or 
+                        segment.get("carrier_code") or 
+                        segment.get("carrierCode") or 
+                        ""
+                    ).upper().strip()
+                    
+                    # 2. 편명 확인
+                    seg_flight_raw = (
+                        segment.get("flight_number") or 
+                        segment.get("flightNumber") or 
+                        segment.get("number") or 
+                        ""
+                    ).upper().strip()
+                    
+                    # 편명에서 숫자만 추출
+                    seg_flight_num_str = "".join(filter(str.isdigit, seg_flight_raw))
+                    seg_flight_num = int(seg_flight_num_str) if seg_flight_num_str else -2
+                    
+                    # 3. 매칭 로직
+                    is_carrier_match = (seg_carrier == airline_code_upper)
+                    is_flight_match = False
+                    
+                    # 편명 숫자가 있으면 숫자끼리 비교 (예: 37 == 0037)
+                    if target_flight_num > 0 and seg_flight_num > 0:
+                        is_flight_match = (target_flight_num == seg_flight_num)
+                    else:
+                        # 숫자가 없으면 전체 문자열 비교
+                        is_flight_match = (flight_number.upper().strip() == seg_flight_raw)
                     
                     # airlineCode와 flightNumber로 매칭
-                    if segment_carrier == airline_code_upper and segment_flight == flight_number_upper:
-                        segments[i]["hasReview"] = has_review
-                        updated = True
+                    if is_carrier_match and is_flight_match:
+                        # 현재 상태와 다를 때만 업데이트
+                        if segment.get("hasReview") != has_review:
+                            segments[i]["hasReview"] = has_review
+                            updated = True
                 
                 # 매칭되는 segment가 있으면 document 업데이트
                 if updated:
                     doc_ref = collection_ref.document(doc.id)
-                    segments_to_update = flight_data["segments"]
+                    # segments 전체를 업데이트
                     await run_in_threadpool(
                         doc_ref.update,
-                        {"segments": segments_to_update}
+                        {"segments": segments}
                     )
                     updated_count += 1
+            
+            print(f"[ReviewStatus] User {user_id}: Updated {updated_count} flights (Req: {airline_code}{flight_number} -> {has_review})")
             
             # 매칭되는 항공편이 없어도 에러 발생하지 않음 (silent fail)
             return True
             
         except Exception as e:
             # 에러가 발생해도 리뷰 생성/삭제는 성공한 것으로 간주
-            # 로깅은 나중에 추가 가능
+            print(f"[ReviewStatus] Error updating review status: {e}")
             return True
 
     async def get_segments_has_review(
@@ -295,7 +334,7 @@ class MyFlightsService:
         사용자의 myFlights를 조회하여 각 segment별 hasReview(true/false)를 반환합니다.
 
         - myFlights 문서에 저장된 segments[*].hasReview 값에 의존하여 그대로 반환합니다.
-          (즉, 별도의 reviews 컬렉션 조회/재계산을 하지 않습니다.)
+        - 다양한 필드명(snake_case, camelCase)을 모두 고려하여 안전하게 값을 추출합니다.
 
         Args:
             user_id: 사용자 ID
@@ -330,6 +369,7 @@ class MyFlightsService:
                 segments_out: List[Dict[str, Any]] = []
                 for seg in raw_segments:
                     seg = seg or {}
+                    # 항공사 코드 추출 (다양한 키 시도)
                     operating_carrier = (
                         seg.get("operating_carrier")
                         or seg.get("operatingCarrier")
@@ -337,12 +377,14 @@ class MyFlightsService:
                         or seg.get("carrierCode")
                         or ""
                     )
+                    # 편명 추출 (다양한 키 시도)
                     flight_number = (
                         seg.get("flight_number")
                         or seg.get("flightNumber")
                         or seg.get("number")
                         or ""
                     )
+                    # hasReview 값 추출 (기본값 False)
                     has_review = bool(seg.get("hasReview", False))
 
                     segments_out.append(


### PR DESCRIPTION
### **변경 사항 (Changes)**

#### 1. `hasReview` 매칭 로직 개선 (`app/feature/flights/my_flights_service.py`)
- **문제점**: 기존 로직이 DB 필드명 불일치(snake_case vs camelCase)나 편명 포맷 차이(`KE0037` vs `37` 등)로 인해 `hasReview` 상태 업데이트에 실패하는 경우가 있었습니다.
- **해결**:
    - **유연한 필드명 조회**: `operating_carrier`, `operatingCarrier`, `carrier_code` 등 다양한 키를 확인하도록 수정했습니다.
    - **편명 숫자 매칭**: 입력된 편명과 저장된 편명에서 **숫자 부분만 추출하여 비교**하는 로직을 추가했습니다. (예: `KE0037` == `37`)
    - **GET 로직 동기화**: 조회 시에도 동일한 유연한 매칭 로직을 적용하여 데이터 일관성을 확보했습니다.

#### 2. 수동 업데이트 API 추가 (`app/feature/flights/my_flights_router.py`)
- **API**: `PUT /users/{user_id}/my-flights/segments/review-status`
- **목적**: 클라이언트에서 리뷰 작성/삭제 후 명시적으로 `hasReview` 상태를 동기화할 수 있도록 지원합니다.
- **Request Body**:
  ```json
  {
    "airlineCode": "KE",
    "flightNumber": "KE0037",
    "hasReview": true
  }
  ```

#### 3. 스키마 추가 (`app/feature/flights/flights_schemas.py`)
- `UpdateReviewStatusRequest` 스키마 추가 (API 요청용)

### **테스트 방법 (How to Test)**
1. `PUT /users/{user_id}/my-flights/segments/review-status` 엔드포인트 호출
2. `airlineCode`: "KE", `flightNumber`: "37" (또는 "0037", "KE0037") 입력
3. `hasReview`: `true`로 설정 후 전송
4. `GET /users/{user_id}/my-flights/segments/has-review` 호출하여 해당 항공편의 `hasReview` 값이 `true`로 변경되었는지 확인

### **관련 이슈 (Related Issues)**
- `hasReview` 상태가 업데이트되지 않는 문제 해결